### PR TITLE
Remove client_id

### DIFF
--- a/Domainr.lbaction/Contents/Scripts/default.js
+++ b/Domainr.lbaction/Contents/Scripts/default.js
@@ -36,7 +36,7 @@ function runWithString(string) {
 }
 
 function api_call(term) {
-    var resp = Lib.Request.getJSON(API_URL, {client_id: "lb6_action", q: encodeURIComponent(term)});
+    var resp = Lib.Request.getJSON(API_URL, {client_id: "{your-mashape-key}", q: encodeURIComponent(term)});
     if (resp.error !== undefined)
         throw "Domainr error ("+resp.error.status+"): "+resp.error.message;
 


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).