### PR TITLE
update Imgur API

### DIFF
--- a/Send to Imgur.lbaction/Contents/Scripts/default.js
+++ b/Send to Imgur.lbaction/Contents/Scripts/default.js
@@ -15,7 +15,7 @@ function run() {
 function runWithPaths(paths) {
     if (Action.preferences.clientID === undefined)
     // https://api.imgur.com/oauth2/addclient
-        Action.preferences.clientID = "CLIENTID";
+        Action.preferences.clientID = "1ef24b069493622";
 
     try {
         var results = paths.map(upload);


### PR DESCRIPTION
Hi there, I took a look at imgur v3 api, and we can still use anonymous way to upload image, just with different endpoint/header/response structure compared with v2.

Although u are not maintaining this thing, I think an update here will help more people since u already have some stars here.

Thanks